### PR TITLE
Display and filter only resource name, instead of full name

### DIFF
--- a/app/src/main/java/tk/zwander/fabricateoverlaysample/data/AvailableResourceItemData.kt
+++ b/app/src/main/java/tk/zwander/fabricateoverlaysample/data/AvailableResourceItemData.kt
@@ -2,6 +2,7 @@ package tk.zwander.fabricateoverlaysample.data
 
 data class AvailableResourceItemData(
     val name: String,
+    val resourceName: String,
     val type: Int,
     val values: Array<String>
 ) : Comparable<AvailableResourceItemData> {

--- a/app/src/main/java/tk/zwander/fabricateoverlaysample/ui/elements/AvailableResourceItem.kt
+++ b/app/src/main/java/tk/zwander/fabricateoverlaysample/ui/elements/AvailableResourceItem.kt
@@ -27,7 +27,7 @@ fun AvailableResourceItem(
                 }.padding(8.dp)
         ) {
             Text(
-                text = data.name
+                text = data.resourceName
             )
 
             Spacer(Modifier.size(8.dp))

--- a/app/src/main/java/tk/zwander/fabricateoverlaysample/ui/elements/dialogs/ListAvailableResourcesDialog.kt
+++ b/app/src/main/java/tk/zwander/fabricateoverlaysample/ui/elements/dialogs/ListAvailableResourcesDialog.kt
@@ -125,7 +125,7 @@ fun ListAvailableResourcesDialog(
                                     items(v.size) {
                                         val item = v[it]
 
-                                        if (item.name.contains(filter, true)) {
+                                        if (item.resourceName.contains(filter, true)) {
                                             AvailableResourceItem(item) { data ->
                                                 resData = data
                                                 showingResDialog = true

--- a/app/src/main/java/tk/zwander/fabricateoverlaysample/util/ResourceUtils.kt
+++ b/app/src/main/java/tk/zwander/fabricateoverlaysample/util/ResourceUtils.kt
@@ -78,6 +78,7 @@ suspend fun getAppResources(
 
                     list[t]!!.add(AvailableResourceItemData(
                         fqrn,
+                        r[0].resourceEntry.key,
                         type,
                         context.getCurrentResourceValue(apk.apkMeta.packageName, fqrn)
                     ))


### PR DESCRIPTION
Makes the resource list a lot more readable with less repetition. 

Search now only includes the resource name as well so searching is more useful

| Before | After|
:--:|:--:
![image](https://user-images.githubusercontent.com/8365233/139914386-3c121d8f-69b0-4af7-9375-7143b13d7ebf.png) | ![image](https://user-images.githubusercontent.com/8365233/139914410-8acf529c-7e27-47d8-9d36-9716fa0df0ea.png)
